### PR TITLE
Add experimentalObjectRestSpread

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ module.exports = {
 	},
 	'parserOptions': {
 		'ecmaVersion': 2017,
-		'sourceType': 'module'
+		'sourceType': 'module',
+		'ecmaFeatures': {
+			'experimentalObjectRestSpread': true
+		}
 	}
 };


### PR DESCRIPTION
Allow the use of object rest spread:

```javascript
const a = {x: 1, y: 2};
const b = {z: 3, ...a};
```